### PR TITLE
Droth 4277 improve open lr encoding for point assets

### DIFF
--- a/src/conversion/openlr/openlr_encoder.ts
+++ b/src/conversion/openlr/openlr_encoder.ts
@@ -49,7 +49,7 @@ export const OpenLREncoder = {
             return openLrBinary.toString('base64');
         } catch (err) {
             if (err instanceof Error) console.error(err.message);
-            throw new Error(`OpenLRException(startMeasure = ${startMeasure}, endMeasure = ${endMeasure}, linkId = ${linkId}, linkLength = ${linkLength}, functionalClass = ${functionalClass}, linkType = ${linkType}, linkGeometry = ${JSON.stringify(linkGeometry)})`);
+            throw new Error(`OpenLRException(startMeasure = ${startMeasure}, endMeasure = ${endMeasure}, linkId = ${linkId}, linkLength = ${linkLength}, functionalClass = ${functionalClass}, linkType = ${linkType}, linkGeometry = ${JSON.stringify(linkGeometry)}, sideCode = ${sideCode})`);
         }
     },
 };

--- a/src/conversion/openlr/openlr_utils.ts
+++ b/src/conversion/openlr/openlr_utils.ts
@@ -1,0 +1,29 @@
+import {SideCode} from "../tn-its/helper/utils";
+import { Orientation } from 'openlr-js/lib/es5/data/location/data/Orientation';
+import { SideOfRoad } from 'openlr-js/lib/es5/data/location/data/SideOfRoad';
+
+export function sideCodeToOpenLROrientation(sideCode: SideCode): Orientation {
+    switch (sideCode) {
+        case SideCode.BothDirections:
+            return Orientation.BOTH;
+        case SideCode.TowardsDigitizing:
+            return Orientation.WITH_LINE_DIRECTION;
+        case SideCode.AgainstDigitizing:
+            return Orientation.AGAINST_LINE_DIRECTION;
+        default:
+            return Orientation.NO_ORIENTATION_OR_UNKNOWN;
+    }
+};
+
+export function locationSpecifierToOpenLRSideOfRoad(locationSpecifier: number): SideOfRoad  {
+    switch (locationSpecifier) {
+        case 1:
+            return SideOfRoad.RIGHT;
+        case 2:
+            return SideOfRoad.LEFT;
+        case 4:
+            return SideOfRoad.BOTH;
+        default:
+            return SideOfRoad.ON_ROAD_OR_UNKNOWN;
+    }
+};

--- a/src/conversion/openlr/openlr_utils.ts
+++ b/src/conversion/openlr/openlr_utils.ts
@@ -1,6 +1,6 @@
-import {SideCode} from "../tn-its/helper/utils";
-import { Orientation } from 'openlr-js/lib/es5/data/location/data/Orientation';
-import { SideOfRoad } from 'openlr-js/lib/es5/data/location/data/SideOfRoad';
+import {LocationSpecifier, SideCode} from "../tn-its/helper/utils";
+import {Orientation} from 'openlr-js/lib/es5/data/location/data/Orientation';
+import {SideOfRoad} from 'openlr-js/lib/es5/data/location/data/SideOfRoad';
 
 export function sideCodeToOpenLROrientation(sideCode: SideCode): Orientation {
     switch (sideCode) {
@@ -15,14 +15,12 @@ export function sideCodeToOpenLROrientation(sideCode: SideCode): Orientation {
     }
 };
 
-export function locationSpecifierToOpenLRSideOfRoad(locationSpecifier: number): SideOfRoad  {
+export function locationSpecifierToOpenLRSideOfRoad(locationSpecifier: LocationSpecifier): SideOfRoad  {
     switch (locationSpecifier) {
-        case 1:
+        case LocationSpecifier.Right:
             return SideOfRoad.RIGHT;
-        case 2:
+        case LocationSpecifier.Left:
             return SideOfRoad.LEFT;
-        case 4:
-            return SideOfRoad.BOTH;
         default:
             return SideOfRoad.ON_ROAD_OR_UNKNOWN;
     }

--- a/src/conversion/tn-its/helper/utils.ts
+++ b/src/conversion/tn-its/helper/utils.ts
@@ -94,3 +94,10 @@ export const validityPeriodOperations = {
         }
     }
 };
+
+export enum SideCode {
+    BothDirections = 1,
+    TowardsDigitizing,
+    AgainstDigitizing,
+    Unknown
+}

--- a/src/conversion/tn-its/helper/utils.ts
+++ b/src/conversion/tn-its/helper/utils.ts
@@ -101,3 +101,12 @@ export enum SideCode {
     AgainstDigitizing,
     Unknown
 }
+
+export enum LocationSpecifier {
+    Right = 1,
+    Left,
+    Above,
+    Middle,
+    AlongRoad,
+    OutsideOfRoad
+}

--- a/src/conversion/tn-its/helper/utils.ts
+++ b/src/conversion/tn-its/helper/utils.ts
@@ -100,7 +100,7 @@ export enum SideCode {
     TowardsDigitizing,
     AgainstDigitizing,
     Unknown
-}
+};
 
 export enum LocationSpecifier {
     Right = 1,
@@ -109,4 +109,4 @@ export enum LocationSpecifier {
     Middle,
     AlongRoad,
     OutsideOfRoad
-}
+};

--- a/src/conversion/tn-its/linear_asset_converter.ts
+++ b/src/conversion/tn-its/linear_asset_converter.ts
@@ -20,13 +20,13 @@ export class LinearTnItsConverter extends AssetConverter {
         const linkLength = link.properties.length; 
         const functionalClass = link.properties.functionalClass;
         const linkType = link.properties['type'];
-
-        const isOppositeDirection = properties.sideCode === 3;
+        const sideCode = properties.sideCode;
+        const isOppositeDirection = sideCode === 3;
         const [linkGeometry, startM, endM] = isOppositeDirection ? 
             [points.reverse(), linkLength - properties.endMeasure, linkLength - properties.startMeasure] :
             [points, properties.startMeasure, properties.endMeasure]
         try {
-            return OpenLREncoder.encodeAssetOnLink(
+            return OpenLREncoder.encodeLinearAssetOnLink(
                 startM, endM, linkGeometry, linkLength, functionalClass, linkType, defaultLinkReference + link.id);
         } catch (err) {
             throw err;           

--- a/src/conversion/tn-its/linear_asset_converter.ts
+++ b/src/conversion/tn-its/linear_asset_converter.ts
@@ -20,8 +20,7 @@ export class LinearTnItsConverter extends AssetConverter {
         const linkLength = link.properties.length; 
         const functionalClass = link.properties.functionalClass;
         const linkType = link.properties['type'];
-        const sideCode = properties.sideCode;
-        const isOppositeDirection = sideCode === 3;
+        const isOppositeDirection = properties.sideCode === 3;
         const [linkGeometry, startM, endM] = isOppositeDirection ? 
             [points.reverse(), linkLength - properties.endMeasure, linkLength - properties.startMeasure] :
             [points, properties.startMeasure, properties.endMeasure]

--- a/src/conversion/tn-its/point_asset_converter.ts
+++ b/src/conversion/tn-its/point_asset_converter.ts
@@ -19,10 +19,9 @@ export class PointTnItsConverter extends AssetConverter {
         const linkLength = link.properties.length;
         const functionalClass = link.properties.functionalClass;
         const linkType = link.properties['type'];
-
-        return OpenLREncoder.encodeAssetOnLink(
+        return OpenLREncoder.encodePointAssetOnLink(
             properties.mValue, properties.mValue, points, linkLength, functionalClass,
-            linkType, defaultLinkReference + link.id);
+            linkType, defaultLinkReference + link.id, properties.sideCode);
     }
 
     properties(assetType: AssetType, feature: PointFeature): RoadFeatureProperties[] {

--- a/test/conversion/point_converter_test.js
+++ b/test/conversion/point_converter_test.js
@@ -22,8 +22,8 @@ describe('Converter: Point asset converter', function() {
         const openLr1 = converter.encodeOpenLRLocationString(change1);
         const openLr2 = converter.encodeOpenLRLocationString(change2);
 
-        assert.equal(openLr1, 'CxMqDCr+zCOcAf98AE0jbPYG');
-        assert.equal(openLr2, 'CxF5iirZbBtnAwDrAHAbduYY');
+        assert.equal(openLr1, 'KxMqDCr+zOOcAf98AE0jTPY=');
+        assert.equal(openLr2, 'KxF5iirZbJtnAwDrAHAbVuY=');
     });
 
     it('Coordinate transform to WSG84 should match', function() {


### PR DESCRIPTION
Haaroitettu assetien OpenLR-muunnos erikseen viivamaisille ja pistemäisille. Viivamaiset jatkavat aikaisemmalla kaavalla, seuraten OpenLR:n 'line'-standardia vaikutussuunnan suhteen. Pistemäisille käytössä uusi 'Point along line' -standardi, jossa vaikutussuunta luetaan Orientation-kentästä. OpenLR:ssä ei ole olemassa kirjaimellisesti pistemäisiä kohteita, vaan 'Point along line' esitetään kahtena äärimmäisen lähekkäisenä pisteenä joiden lukusuunta katsotaan Orientation-kentästä. Orientation mäpätään Digiroadin SideCodesta.

SideOfRoad-attribuutti otettu samassa yhteydessä mukaan pistemäisille, mutta sen arvo määrittyy tällä hetkellä tuntemattomaksi kaikissa tapauksissa. Tämä johtuu siitä, ettei muutosApi toimita arvon määrittämiseen vaadittavaa location_specifier -tietoa TN-ITS:lle. location_specifier lisätään myöhemmin muutosApin outputiin toisessa tiketissä, mikäli asiakas näkee sen tarpeelliseksi. SideOfRoadin tilanne lisätään dokumentaatioon.